### PR TITLE
Messages have correct timestamps, added in the controller

### DIFF
--- a/app/javascript/controllers/timezone_controller.js
+++ b/app/javascript/controllers/timezone_controller.js
@@ -1,17 +1,17 @@
 import { Controller } from "@hotwired/stimulus"
 
-export default class extends Controller {
+export class TimezoneController extends Controller {
     static targets = ["time"]
 
-    connect() {
-        this.convertToLocalTime();
+    timeTargetConnected(element) {
+        this.#convertToLocalTime(element);
     }
 
-    convertToLocalTime() {
-        this.timeTargets.forEach((element) => {
-            const utcTime = new Date(element.dataset.utcTime)
-            const newTime = utcTime.toLocaleString("en-US", {timeZone: "America/New_York"})
-            element.innerText = newTime
-        });
+    #convertToLocalTime(element) {
+        const utcTime = new Date(element.dataset.utcTime)
+        element.innerText =
+          utcTime.toLocaleString("pl-PL", {
+              timeZone: "Europe/Warsaw"
+          })
     }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <title><%= content_for(:title) || "Rails Live Chat" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= yield :head %>


### PR DESCRIPTION
I read your [article](https://hashrocket.com/blog/posts/the-rails-renaissance) and played around with the demo app. 
I noticed that timestamp does not show up when message is created (it does show up, however, for all messages that are displayed when page is loaded initially). 
This small change to the controller will make it work as expected.